### PR TITLE
handleNetworkChange 先判断 runnable 是否为 null

### DIFF
--- a/android/src/main/java/com/example/r_upgrade/common/UpgradeService.java
+++ b/android/src/main/java/com/example/r_upgrade/common/UpgradeService.java
@@ -139,6 +139,12 @@ public class UpgradeService extends Service {
     }
 
     private void handleNetworkChange(boolean isConnected) {
+        // 崩溃收集平台监测到 runnable.id 有空指针崩溃，崩溃机型为 OPPO 和 VIVO。
+        // 排查 handleNetworkChange 如果在 onStartCommand 前回调两次会引起空指针异常
+        if (runnable == null) {
+            return;
+        }
+        
         if (isConnected) {
             RUpgradeLogger.get().d(TAG, "onReceive: 当前网络正在连接");
             if (isFirst) {


### PR DESCRIPTION
通过日志分析，onCreate 和 onStartCommand 中间可能会收到网络状态变化，这时可能会导致 调用` long id = runnable.id;` 时发生崩溃