### PR TITLE
no need for storage permissions on sdk 30+

### DIFF
--- a/android/src/main/java/com/example/r_upgrade/common/StoragePermissions.java
+++ b/android/src/main/java/com/example/r_upgrade/common/StoragePermissions.java
@@ -3,6 +3,7 @@ package com.example.r_upgrade.common;
 import android.Manifest;
 import android.app.Activity;
 import android.content.pm.PackageManager;
+import android.os.Build;
 
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.ActivityCompat;
@@ -29,7 +30,7 @@ public class StoragePermissions {
         if (ongoing) {
             callback.onResult("storagePermission", "Read/Write External Storage permission request ongoing");
         }
-        if (!hasReadStoragePermission(activity) || !hasWritePermission(activity)) {
+        if (Build.VERSION.SDK_INT < 30 && (!hasReadStoragePermission(activity) || !hasWritePermission(activity))) {
             permissionsRegistry.addListener(
                     new StorageRequestPermissionsListener(new ResultCallback() {
                         @Override


### PR DESCRIPTION
external storage read/write permissions are not needed with sdk 30+, and requesting them can fail on 33